### PR TITLE
Name Change

### DIFF
--- a/PF2e
+++ b/PF2e
@@ -57,7 +57,7 @@ Hooks.once("canvasInit", () => {
 
 Hooks.once("dragRuler.ready", (SpeedProvider) => {
 // When dragruler is ready to go give it all the PF2 specific stuff
-	class PF2ESpeedProvider extends SpeedProvider {
+	class PF2eSpeedProvider extends SpeedProvider {
 //Registers colours for up to four movement actions so colours can be customized for them, and sets defaults
 get colors() {
 	return [
@@ -124,7 +124,7 @@ getCostForStep(token, area){
 		 }
 	};
 };
-	dragRuler.registerModule("pf2e-dragruler", PF2ESpeedProvider) //register the speed provider so its selectable from the drag ruler configuration.
+	dragRuler.registerModule("pf2e-dragruler", PF2eSpeedProvider) //register the speed provider so its selectable from the drag ruler configuration.
 });
 
 function cleanSpeed(token, type) {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Either Enhanced Terrain Layer(https://github.com/ironmonk88/enhanced-terrain-lay
 
 ![Slowed Example](https://imgur.com/49ZJDF6.png)
 
-Drag Ruler now supports customizable colours. The default colours for PF2E integration should be distinguishable for people with protanopia, deuteranopia, or tritanopia.
+Drag Ruler now supports customizable colours. The default colours for PF2e integration should be distinguishable for people with protanopia, deuteranopia, or tritanopia.
 
 Settings exist to automatically switch to use fly speed, if a creature has one, when a token is elevated, and autpmatically switch to burrow speed if a token has negative elevation. This same setting also supports switching to swim speed if you move begins in water, or aquatic terrain. Tokens without the appropriate speed will default to their land speed instead. And will not be treated as flying or swimming for the purposes of difficult terrain. 
 

--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
     "name": "pf2e-dragruler",
-    "title": "PF2E Drag Ruler Integration",
+    "title": "PF2e Drag Ruler Integration",
     "description": "Integration of Drag Ruler module (https://github.com/manuelVo/foundryvtt-drag-ruler) for Pathfinder 2e with support for the 3 action enconomy, and quickened, slowed and stunned conditions.",
     "version": "0.6.1",
     "author": "Velara [Avery#9136]",


### PR DESCRIPTION
Here's the name change from PF2E to PF2e we talked about a few months ago. There's no need to update the module because of this, but might as well add it in so the next update it change.

I've mostly given up on convincing everyone to switch, but if you're interested in the stats, 83% now use PF2e. 86% after this.