### PR TITLE
Fix authors in manifest

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,16 +2,17 @@
   "title": "PF2e Drag Ruler Integration",
   "version": "2.1.8",
   "description": "Integration of Drag Ruler module (https://github.com/manuelVo/foundryvtt-drag-ruler) for Pathfinder 2e with support for the 3 action enconomy, and conditions.",
-  "compatibility":{
+  "compatibility": {
     "minimum": "10",
     "verified": "10",
     "maximum": "10"
   },
-  "authors":
-  {
-    "name":"Avery",
-    "discord": "Avery#9136"
-  },
+  "authors": [
+    {
+      "name": "Avery",
+      "discord": "Avery#9136"
+    }
+  ],
   "packs": [
     {
       "name": "movement-effects",
@@ -32,10 +33,11 @@
       "flags": {}
     }
   ],
-  "esmodules": ["js/main.js"],
+  "esmodules": [
+    "js/main.js"
+  ],
   "socket": true,
-  "manifest": "https://raw.githubusercontent.com/League-of-Foundry-Developers/pf2edragruler/main/module.json",
-
+  "manifest": "https://raw.githubusercontent.com/JDCalvert/pf2edragruler/main/module.json",
   "download": "https://github.com/League-of-Foundry-Developers/pf2edragruler/archive/refs/tags/v2.1.8.zip",
   "url": "https://github.com/League-of-Foundry-Developers/pf2edragruler",
   "id": "pf2e-dragruler",
@@ -48,11 +50,11 @@
       }
     ],
     "requires": [
-			{
-				"id": "drag-ruler",
-				"type": "module",
-				"manifest": "https://raw.githubusercontent.com/manuelVo/foundryvtt-drag-ruler/v1.13.0/module.json"
-			}
-		]
+      {
+        "id": "drag-ruler",
+        "type": "module",
+        "manifest": "https://raw.githubusercontent.com/manuelVo/foundryvtt-drag-ruler/v1.13.0/module.json"
+      }
+    ]
   }
 }

--- a/module.json
+++ b/module.json
@@ -37,7 +37,7 @@
     "js/main.js"
   ],
   "socket": true,
-  "manifest": "https://raw.githubusercontent.com/JDCalvert/pf2edragruler/main/module.json",
+  "manifest": "https://raw.githubusercontent.com/League-of-Foundry-Developers/pf2edragruler/main/module.json",
   "download": "https://github.com/League-of-Foundry-Developers/pf2edragruler/archive/refs/tags/v2.1.8.zip",
   "url": "https://github.com/League-of-Foundry-Developers/pf2edragruler",
   "id": "pf2e-dragruler",


### PR DESCRIPTION
Small change to the manifest to fix the authors entry - this should be an array in Foundry v10. Also auto-formatted the file.