### PR TITLE
Fixed undefined combatant spamming errors

### DIFF
--- a/js/movementFunctions.js
+++ b/js/movementFunctions.js
@@ -81,7 +81,7 @@ export function movementTracking (token){
 if (game.combats.active && game.settings.get("pf2e-dragruler", "partialMovements") && game.settings.get("drag-ruler", "enableMovementHistory")){
   const combat = game.combats.active
   const combatant = combat.getCombatantByToken(token.id);
-  var moveHistory = combatant.flags?.dragRuler?.passedWaypoints
+  var moveHistory = combatant?.flags?.dragRuler?.passedWaypoints
   if (moveHistory == undefined){
   var A1 = baseSpeed;
   var A2 = baseSpeed*2;


### PR DESCRIPTION
Added an extra optional chaining operator to prevent the function from trying to access an undefined combatant. Otherwise, if a token that's not on the active combat tracker is dragged, the combatant will be undefined and spam errors about accessing its flags while also preventing the use of Drag Ruler for the token.